### PR TITLE
Feature/dirtiness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 npm-debug.log*
 
 /data
+**/.DS_STORE

--- a/lib/number-utils.js
+++ b/lib/number-utils.js
@@ -1,3 +1,10 @@
+module.exports = {
+  isNumber,
+  isValidNumber,
+  validNumberOrDefault,
+  clamp
+}
+
 function isNumber (number) {
   return typeof (number) === 'number'
 }
@@ -18,11 +25,4 @@ function clamp (min, n, max) {
   } else {
     return n
   }
-}
-
-module.exports = {
-  isNumber,
-  isValidNumber,
-  validNumberOrDefault,
-  clamp
 }

--- a/lib/string-utils.js
+++ b/lib/string-utils.js
@@ -2,15 +2,15 @@ const assert = require('assert')
 const { isNil } = require('lodash')
 
 module.exports = {
-  pluralize  
+  pluralize
 }
 
-function pluralize(length, single, plural) {
-  plural = plural || single + 's';
+function pluralize (length, single, plural) {
+  plural = plural || single + 's'
 
-  assert('pluralize requires a singular string', single);
-  assert('pluralize requires a length', !isNil(length));
+  assert('pluralize requires a singular string', single)
+  assert('pluralize requires a length', !isNil(length))
 
-  return (length === 1) ? single : plural;
+  return (length === 1) ? single : plural
 }
 

--- a/lib/string-utils.js
+++ b/lib/string-utils.js
@@ -1,0 +1,16 @@
+const assert = require('assert')
+const { isNil } = require('lodash')
+
+module.exports = {
+  pluralize  
+}
+
+function pluralize(length, single, plural) {
+  plural = plural || single + 's';
+
+  assert('pluralize requires a singular string', single);
+  assert('pluralize requires a length', !isNil(length));
+
+  return (length === 1) ? single : plural;
+}
+

--- a/metas/getters.js
+++ b/metas/getters.js
@@ -1,5 +1,7 @@
 const getMetas = (state) => state.metas.records
+const getMetasDirty = (state) => state.metas.dirty
 
 module.exports = {
-  getMetas
+  getMetas,
+  getMetasDirty
 }

--- a/metas/getters.js
+++ b/metas/getters.js
@@ -1,5 +1,3 @@
-// const { createSelector: Getter, createStructuredSelector: Struct } = require('reselect')
-
 const getMetas = (state) => state.metas.records
 
 module.exports = {

--- a/metas/reducer.js
+++ b/metas/reducer.js
@@ -1,6 +1,6 @@
 const { Effects, loop } = require('redux-loop')
 const { handleActions } = require('redux-actions')
-const { merge, keyBy, without, includes } = require('lodash')
+const { merge, keyBy, without } = require('lodash')
 const assert = require('assert')
 
 const {

--- a/mixes/containers/mix-list.js
+++ b/mixes/containers/mix-list.js
@@ -7,11 +7,11 @@ const { loadMixList, createMix } = require('../actions')
 
 class MixListContainer extends React.Component {
   render () {
-    const { mixList, isLoading, error, createMix } = this.props
+    const { mixList, isLoadingList, error, createMix } = this.props
 
     return <div>
       <header>
-        <div>mixes are {isLoading ? 'loading' : 'here'}</div>
+        <div>mixes are {isLoadingList ? 'loading' : 'here'}</div>
         <div>{error || 'no errors'}</div>
         <button onClick={createMix}>Create Mix</button>
       </header>

--- a/mixes/containers/mix.js
+++ b/mixes/containers/mix.js
@@ -71,7 +71,7 @@ module.exports = connect(
       )
     }
 
-    console.log("OWN PROPS", ownProps)
+    console.log('OWN PROPS', ownProps)
     return { ...props, mix, mixId: currentMixId }
   },
   { saveMix, loadMix, deleteMix, updateMeta }

--- a/mixes/containers/mix.js
+++ b/mixes/containers/mix.js
@@ -13,10 +13,11 @@ class MixContainer extends React.Component {
   }
 
   render () {
-    const { mix, isLoading, isSaving, error, saveMix, deleteMix } = this.props
+    const { mix, error, saveMix, deleteMix } = this.props
     if (!mix) { return null }
-
     console.log('mix', mix)
+
+    const { isSaving, isLoading, isDirty } = mix
     const titleElement = isLoading
       ? <div>'{mix.meta.title}' is loading</div>
       : <input type='text'
@@ -28,7 +29,7 @@ class MixContainer extends React.Component {
       <header>
         {titleElement}
         <div>{error || 'no errors'}</div>
-        <button disabled={isLoading || isSaving} onClick={() => saveMix(mix)}>
+        <button disabled={!isDirty || (isLoading || isSaving)} onClick={() => saveMix(mix)}>
           Save Mix
         </button>
         <button disabled={isLoading || isSaving} onClick={() => deleteMix(mix)}>
@@ -58,7 +59,20 @@ module.exports = connect(
   (state, ownProps) => {
     const props = getMixProps(state)
     const currentMixId = ownProps.params.mixId
-    return { ...props, mixId: currentMixId, mix: props.mixes[currentMixId] }
+    const { router, route } = ownProps
+    const mix = props.mixes[currentMixId]
+
+    if (mix) {
+      router.setRouteLeaveHook(
+        route,
+        // TODO: do i need to back out all changes if confirm? how to do that cleanly - LOAD_MIX? ROLLBACK_MIX?
+        () => !mix.isDirty ||
+          window.confirm('You have unsaved changes that will be lost if you leave this page.')
+      )
+    }
+
+    console.log("OWN PROPS", ownProps)
+    return { ...props, mix, mixId: currentMixId }
   },
   { saveMix, loadMix, deleteMix, updateMeta }
 )(MixContainer)

--- a/mixes/getters.js
+++ b/mixes/getters.js
@@ -1,15 +1,17 @@
 const { createSelector: Getter, createStructuredSelector: Struct } = require('reselect')
-const { mapValues, values, omitBy, isNil } = require('lodash')
+const { mapValues, values, omitBy, isNil, includes } = require('lodash')
 
-const { getMetas } = require('../metas/getters')
+const { getMetas, getMetasDirty } = require('../metas/getters')
 const { getChannels } = require('../channels/getters')
 const { getClips } = require('../clips/getters')
 const nestMix = require('./helpers/nest')
 const { getPrimaryTracks } = require('./helpers/get-tracks')
 
 const getMixesRecords = (state) => state.mixes.records
-const getMixesIsLoading = (state) => state.mixes.isLoading
-const getMixesIsSaving = (state) => state.mixes.isSaving
+const getMixesIsLoadingList = (state) => state.mixes.isLoadingList
+const getMixesSaving = (state) => state.mixes.saving
+const getMixesLoading = (state) => state.mixes.loading
+const getMixesDirty = (state) => state.mixes.dirty
 const getMixesError = (state) => state.mixes.error
 
 const getMixes = Getter(
@@ -17,14 +19,21 @@ const getMixes = Getter(
   getMetas,
   getChannels,
   getClips,
-  (mixes, metas, channels, clips) => {
+  getMixesSaving,
+  getMixesLoading,
+  getMixesDirty,
+  getMetasDirty,
+  (mixes, metas, channels, clips, saving, loading, dirtyMixes, dirtyMetas) => {
     return omitBy(mapValues(mixes, (flatMix, mixId) => {
       if (channels[flatMix.channelId]) {
         const nestedMix = nestMix({ ...flatMix, channels, clips })
         return {
           ...nestedMix,
           meta: metas[nestedMix.id] || {},
-          primaryTracks: getPrimaryTracks(nestedMix, metas)
+          primaryTracks: getPrimaryTracks(nestedMix, metas),
+          isLoading: includes(loading, nestedMix.id),
+          isSaving: includes(saving, nestedMix.id),
+          isDirty: includes(dirtyMixes, nestedMix.id) || includes(dirtyMetas, nestedMix.id)
         }
       }
     }), isNil)
@@ -37,17 +46,13 @@ const getMixList = Getter(
 )
 
 const getMixListProps = Struct({
-  mixes: getMixes,
   mixList: getMixList,
-  isLoading: getMixesIsLoading,
-  isSaving: getMixesIsSaving,
+  isLoadingList: getMixesIsLoadingList,
   error: getMixesError
 })
 
 const getMixProps = Struct({
   mixes: getMixes,
-  isLoading: getMixesIsLoading,
-  isSaving: getMixesIsSaving,
   error: getMixesError
 })
 

--- a/mixes/reducer.js
+++ b/mixes/reducer.js
@@ -1,7 +1,7 @@
 const { Effects, loop } = require('redux-loop')
 const { handleActions } = require('redux-actions')
 const { push } = require('react-router-redux')
-const { pick, without, includes } = require('lodash')
+const { pick, without } = require('lodash')
 const uuid = require('uuid/v4')
 
 const {

--- a/mixes/reducer.js
+++ b/mixes/reducer.js
@@ -1,7 +1,7 @@
 const { Effects, loop } = require('redux-loop')
 const { handleActions } = require('redux-actions')
 const { push } = require('react-router-redux')
-const { pick } = require('lodash')
+const { pick, without, includes } = require('lodash')
 const uuid = require('uuid/v4')
 
 const {
@@ -46,7 +46,7 @@ function createReducer (config) {
 
   return handleActions({
     [loadMixList]: (state, action) => loop({
-      ...state, isLoading: true
+      ...state, isLoadingList: true
     }, Effects.batch([
       Effects.constant(loadMetaList()),
       Effects.promise(runLoadMixList),
@@ -59,41 +59,45 @@ function createReducer (config) {
       ...state, error: action.payload.message
     }),
     [loadMixListEnd]: (state, action) => ({
-      ...state, isLoading: false
+      ...state, isLoadingList: false
     }),
     [loadMix]: (state, action) => loop({
-      ...state, isLoading: true
+      ...state, loading: [...state.loading, action.payload]
     }, Effects.batch([
       Effects.promise(runLoadMix, action.payload),
-      Effects.constant(loadMixEnd())
+      Effects.constant(loadMixEnd(action.payload))
     ])),
-    [loadMixSuccess]: (state, action) => loop(state,
-      Effects.constant(setMix(action.payload))),
+    [loadMixSuccess]: (state, action) => loop({
+      ...state,
+      dirty: without(state.dirty, action.payload.id)
+    }, Effects.constant(setMix(action.payload))),
     [loadMixFailure]: (state, action) => ({
       ...state, error: action.payload.message
     }),
     [loadMixEnd]: (state, action) => ({
-      ...state, isLoading: false
+      ...state, loading: without(state.loading, action.payload)
     }),
     [saveMix]: (state, action) => loop({
-      ...state, isSaving: true
+      ...state, saving: [...state.saving, action.payload.id]
     }, Effects.batch([
       Effects.promise(runSaveMix, action.payload),
-      Effects.constant(saveMixEnd())
+      Effects.constant(saveMixEnd(action.payload.id))
     ])),
-    [saveMixSuccess]: (state, action) => loop(state,
-      Effects.constant(saveMeta(action.payload.id))),
+    [saveMixSuccess]: (state, action) => loop({
+      ...state,
+      dirty: without(state.dirty, action.payload.id)
+    }, Effects.constant(saveMeta(action.payload.id))),
     [saveMixFailure]: (state, action) => ({
       ...state, error: action.payload.message
     }),
     [saveMixEnd]: (state, action) => ({
-      ...state, isSaving: false
+      ...state, saving: without(state.saving, action.payload)
     }),
     [deleteMix]: (state, action) => loop({
-      ...state, isSaving: true
+      ...state, saving: [...state.saving, action.payload.id]
     }, Effects.batch([
       Effects.promise(runDeleteMix, action.payload),
-      Effects.constant(deleteMixEnd())
+      Effects.constant(deleteMixEnd(action.payload.id))
     ])),
     [deleteMixSuccess]: (state, action) => {
       const nestedMix = action.payload
@@ -103,7 +107,11 @@ function createReducer (config) {
 
       // TODO: we need to do the inverse of setChannels, setClips. how?
 
-      return loop({ ...state, records: nextRecords }, Effects.batch([
+      return loop({
+        ...state,
+        dirty: without(state.dirty, nestedMix.id),
+        records: nextRecords
+      }, Effects.batch([
         Effects.constant(deleteMeta(nestedMix.id)),
         Effects.constant(navigateToMixList())
       ]))
@@ -112,7 +120,7 @@ function createReducer (config) {
       ...state, error: action.payload.message
     }),
     [deleteMixEnd]: (state, action) => ({
-      ...state, isSaving: false
+      ...state, saving: without(state.saving, action.payload)
     }),
     [setMix]: (state, action) => {
       const { records } = state
@@ -142,15 +150,20 @@ function createReducer (config) {
         })),
         Effects.constant(navigateToMix(newMix.id))
       ])
-      return loop(state, effects)
+      return loop({
+        ...state,
+        dirty: [...state.dirty, newMix.id]
+      }, effects)
     },
     [navigateToMix]: (state, action) => loop(state,
       Effects.constant(push(`/mixes/${action.payload}`))),
     [navigateToMixList]: (state, action) => loop(state,
       Effects.constant(push('/mixes/')))
   }, {
-    isLoading: false,
-    isSaving: false,
+    isLoadingList: false,
+    loading: [],
+    saving: [],
+    dirty: [],
     records: {},
     error: null
   })

--- a/samples/containers/sample-list.js
+++ b/samples/containers/sample-list.js
@@ -6,6 +6,7 @@ const { forEach, filter, isEmpty } = require('lodash')
 
 const { getSampleListProps } = require('../getters')
 const { loadSampleList, createSample } = require('../actions')
+const { pluralize } = require('../../lib/string-utils')
 
 class SampleListContainer extends React.Component {
   onFilesDrop (e) {
@@ -21,9 +22,14 @@ class SampleListContainer extends React.Component {
   }
 
   render () {
-    const { sampleList, isLoading, isCreating, error } = this.props
-    const isAnalyzing = !isEmpty(filter(sampleList, { isAnalyzing: true }))
+    const { sampleList, isLoading, creatingSamples, error } = this.props
+    const analyzingSamples = filter(sampleList, { isAnalyzing: true })
+    const isAnalyzing = !isEmpty(analyzingSamples)
+    const isCreating = !isEmpty(creatingSamples)
 
+    const creatingText = `creating ${creatingSamples.length} ${pluralize(creatingSamples.length, 'sample')}…`
+    const analyzingText = `analyzing ${analyzingSamples.length} ${pluralize(analyzingSamples.length, 'sample')}…`
+    
     console.log('sampleList', sampleList)
 
     return <div>
@@ -32,8 +38,8 @@ class SampleListContainer extends React.Component {
         onFrameDrop={this.onFilesDrop.bind(this)} />
       <header>
         <div>samples are {isLoading ? 'loading' : 'here'}</div>
-        {isCreating && <div>'creating samples…'</div>}
-        {isAnalyzing && <div>'analyzing samples…'</div>}
+        {isCreating && <div>{creatingText}</div>}
+        {isAnalyzing && <div>{analyzingText}</div>}
         <div>{error || 'no errors'}</div>
       </header>
       {sampleList.map(sample => {

--- a/samples/containers/sample-list.js
+++ b/samples/containers/sample-list.js
@@ -29,7 +29,7 @@ class SampleListContainer extends React.Component {
 
     const creatingText = `creating ${creatingSamples.length} ${pluralize(creatingSamples.length, 'sample')}…`
     const analyzingText = `analyzing ${analyzingSamples.length} ${pluralize(analyzingSamples.length, 'sample')}…`
-    
+
     console.log('sampleList', sampleList)
 
     return <div>

--- a/samples/containers/sample-list.js
+++ b/samples/containers/sample-list.js
@@ -2,7 +2,7 @@ const React = require('react')
 const { connect } = require('react-redux')
 const { Link } = require('react-router')
 const FileDrop = require('react-file-drop')
-const { forEach } = require('lodash')
+const { forEach, filter, isEmpty } = require('lodash')
 
 const { getSampleListProps } = require('../getters')
 const { loadSampleList, createSample } = require('../actions')
@@ -21,7 +21,8 @@ class SampleListContainer extends React.Component {
   }
 
   render () {
-    const { sampleList, isLoading, isCreating, isAnalyzing, error } = this.props
+    const { sampleList, isLoading, isCreating, error } = this.props
+    const isAnalyzing = !isEmpty(filter(sampleList, { isAnalyzing: true }))
 
     console.log('sampleList', sampleList)
 

--- a/samples/containers/sample-list.js
+++ b/samples/containers/sample-list.js
@@ -22,7 +22,7 @@ class SampleListContainer extends React.Component {
   }
 
   render () {
-    const { sampleList, isLoading, creatingSamples, error } = this.props
+    const { sampleList, isLoadingList, creatingSamples, error } = this.props
     const analyzingSamples = filter(sampleList, { isAnalyzing: true })
     const isAnalyzing = !isEmpty(analyzingSamples)
     const isCreating = !isEmpty(creatingSamples)
@@ -37,7 +37,7 @@ class SampleListContainer extends React.Component {
         frame={document}
         onFrameDrop={this.onFilesDrop.bind(this)} />
       <header>
-        <div>samples are {isLoading ? 'loading' : 'here'}</div>
+        <div>samples are {isLoadingList ? 'loading' : 'here'}</div>
         {isCreating && <div>{creatingText}</div>}
         {isAnalyzing && <div>{analyzingText}</div>}
         <div>{error || 'no errors'}</div>

--- a/samples/containers/sample.js
+++ b/samples/containers/sample.js
@@ -8,7 +8,8 @@ const Waveform = require('../../lib/react-waveform')
 
 class SampleContainer extends React.Component {
   render () {
-    const { sample, isLoading, isAnalyzing, error } = this.props
+    const { sample, isLoading, error } = this.props
+    const { isAnalyzing } = sample
     console.log('sample', sample)
 
     return <div>

--- a/samples/containers/sample.js
+++ b/samples/containers/sample.js
@@ -8,8 +8,8 @@ const Waveform = require('../../lib/react-waveform')
 
 class SampleContainer extends React.Component {
   render () {
-    const { sample, isLoading, error } = this.props
-    const { isAnalyzing } = sample
+    const { sample, error } = this.props
+    const { isAnalyzing, isLoading } = sample
     console.log('sample', sample)
 
     return <div>
@@ -31,7 +31,7 @@ class SampleContainer extends React.Component {
     const { loadSample, sample } = this.props
 
     if (sample && !sample.audioBuffer) {
-      loadSample({ id: sample.id })
+      loadSample(sample.id)
     }
   }
 }

--- a/samples/getters.js
+++ b/samples/getters.js
@@ -5,7 +5,7 @@ const { getMetas } = require('../metas/getters')
 
 const getSamplesRecords = (state) => state.samples.records
 const getSamplesIsLoading = (state) => state.samples.isLoading
-const getSamplesIsCreating = (state) => state.samples.isCreating
+const getSamplesCreating = (state) => state.samples.creating
 const getSamplesError = (state) => state.samples.error
 const getSamplesAnalyzing = (state) => state.samples.analyzing
 
@@ -29,14 +29,13 @@ const getSampleListProps = Struct({
   samples: getSamples,
   sampleList: getSampleList,
   isLoading: getSamplesIsLoading,
-  isCreating: getSamplesIsCreating,
+  creatingSamples: getSamplesCreating,
   error: getSamplesError
 })
 
 const getSampleProps = Struct({
   samples: getSamples,
   isLoading: getSamplesIsLoading,
-  isCreating: getSamplesIsCreating,
   error: getSamplesError
 })
 

--- a/samples/getters.js
+++ b/samples/getters.js
@@ -4,19 +4,22 @@ const { mapValues, values, includes } = require('lodash')
 const { getMetas } = require('../metas/getters')
 
 const getSamplesRecords = (state) => state.samples.records
-const getSamplesIsLoading = (state) => state.samples.isLoading
+const getSampleListIsLoading = (state) => state.samples.isLoadingList
 const getSamplesCreating = (state) => state.samples.creating
-const getSamplesError = (state) => state.samples.error
 const getSamplesAnalyzing = (state) => state.samples.analyzing
+const getSamplesLoading = (state) => state.samples.loading
+const getSamplesError = (state) => state.samples.error
 
 const getSamples = Getter(
   getSamplesRecords,
   getMetas,
   getSamplesAnalyzing,
-  (samples, metas, analyzing) => mapValues(samples, (sample, sampleId) => ({
+  getSamplesLoading,
+  (samples, metas, analyzing, loading) => mapValues(samples, (sample, sampleId) => ({
     ...sample,
     meta: metas[sampleId] || {},
-    isAnalyzing: includes(analyzing, sampleId)
+    isAnalyzing: includes(analyzing, sampleId),
+    isLoading: includes(loading, sampleId)
   }))
 )
 
@@ -28,14 +31,13 @@ const getSampleList = Getter(
 const getSampleListProps = Struct({
   samples: getSamples,
   sampleList: getSampleList,
-  isLoading: getSamplesIsLoading,
+  isLoadingList: getSampleListIsLoading,
   creatingSamples: getSamplesCreating,
   error: getSamplesError
 })
 
 const getSampleProps = Struct({
   samples: getSamples,
-  isLoading: getSamplesIsLoading,
   error: getSamplesError
 })
 

--- a/samples/getters.js
+++ b/samples/getters.js
@@ -1,21 +1,23 @@
 const { createSelector: Getter, createStructuredSelector: Struct } = require('reselect')
-const { mapValues, values, omitBy, isNil } = require('lodash')
+const { mapValues, values, includes } = require('lodash')
 
 const { getMetas } = require('../metas/getters')
 
 const getSamplesRecords = (state) => state.samples.records
 const getSamplesIsLoading = (state) => state.samples.isLoading
 const getSamplesIsCreating = (state) => state.samples.isCreating
-const getSamplesIsAnalyzing = (state) => state.samples.isAnalyzing
 const getSamplesError = (state) => state.samples.error
+const getSamplesAnalyzing = (state) => state.samples.analyzing
 
 const getSamples = Getter(
   getSamplesRecords,
   getMetas,
-  (samples, metas) => omitBy(mapValues(samples, (sample, sampleId) => ({
+  getSamplesAnalyzing,
+  (samples, metas, analyzing) => mapValues(samples, (sample, sampleId) => ({
     ...sample,
-    meta: metas[sampleId] || {}
-  })), isNil)
+    meta: metas[sampleId] || {},
+    isAnalyzing: includes(analyzing, sampleId)
+  }))
 )
 
 const getSampleList = Getter(
@@ -28,7 +30,6 @@ const getSampleListProps = Struct({
   sampleList: getSampleList,
   isLoading: getSamplesIsLoading,
   isCreating: getSamplesIsCreating,
-  isAnalyzing: getSamplesIsAnalyzing,
   error: getSamplesError
 })
 
@@ -36,7 +37,6 @@ const getSampleProps = Struct({
   samples: getSamples,
   isLoading: getSamplesIsLoading,
   isCreating: getSamplesIsCreating,
-  isAnalyzing: getSamplesIsAnalyzing,
   error: getSamplesError
 })
 

--- a/samples/reducer.js
+++ b/samples/reducer.js
@@ -37,7 +37,7 @@ function createReducer (config) {
 
   return handleActions({
     [loadSampleList]: (state, action) => loop({
-      ...state, isLoading: true
+      ...state, isLoadingList: true
     }, Effects.batch([
       Effects.constant(loadMetaList()),
       Effects.promise(runLoadSampleList),
@@ -51,7 +51,7 @@ function createReducer (config) {
       ...state, error: action.payload.message
     }),
     [loadSampleListEnd]: (state, action) => ({
-      ...state, isLoading: false
+      ...state, isLoadingList: false
     }),
     [loadSample]: (state, action) => {
       const id = action.payload
@@ -60,10 +60,10 @@ function createReducer (config) {
         return state
       } else {
         return loop({
-          ...state, isLoading: true
+          ...state, loading: [...state.loading, id]
         }, Effects.batch([
-          Effects.promise(runLoadSample, action.payload.id),
-          Effects.constant(loadSampleEnd())
+          Effects.promise(runLoadSample, id),
+          Effects.constant(loadSampleEnd(id))
         ]))
       }
     },
@@ -78,7 +78,7 @@ function createReducer (config) {
       ...state, error: action.payload.message
     }),
     [loadSampleEnd]: (state, action) => ({
-      ...state, isLoading: false
+      ...state, loading: without(state.loading, action.payload)
     }),
     [createSample]: (state, action) => {
       const file = action.payload
@@ -147,8 +147,9 @@ function createReducer (config) {
       ...state, analyzing: without(state.analyzing, action.payload)
     })
   }, {
+    isLoadingList: false,
     creating: [],
-    isLoading: false,
+    loading: [],
     analyzing: [],
     records: {},
     error: null

--- a/samples/service.js
+++ b/samples/service.js
@@ -3,7 +3,7 @@ const fsRaw = require('fs')
 const fs = pify(fsRaw)
 const { join } = require('path')
 const crypto = require('crypto')
-const { merge, omitBy, isNil } = require('lodash')
+const { omitBy, isNil } = require('lodash')
 const JsMediaTags = require('jsmediatags')
 
 const { validNumberOrDefault } = require('../lib/number-utils')
@@ -43,7 +43,7 @@ function createService (config) {
         return audioContext.decodeAudioData(buffer)
           .then(audioBuffer => ({ data, audioBuffer }))
       })
-      .then(({ data, audioBuffer }) => ({ id, path, data, audioBuffer }))
+      .then(({ data, audioBuffer }) => ({ sample: { id, audioBuffer }, path, data }))
   }
 
   function createSample (file) {
@@ -52,12 +52,12 @@ function createService (config) {
 
       // dedupe against checksum: if sample doesnt exist, create
       return readSample(id)
-        .then(sample => merge({ isDuplicateSample: true }, sample))
+        .then(({ sample }) => ({ sample, isDuplicate: true }))
         .catch(error => {
           if (error && error.code === 'ENOENT') {
             // TODO: is there a clean way to not have to read the file so many times?
             return fs.writeFile(_getSamplePath(id), data).then(() => {
-              return readSample(id).then(sample => merge({ file }, sample))
+              return readSample(id).then(({ sample }) => ({ sample, file }))
             })
           } else {
             return Promise.reject(error)
@@ -67,7 +67,9 @@ function createService (config) {
   }
 
   function analyzeSample (id) {
-    return readSample(id).then(({ path, data, audioBuffer }) => {
+    return readSample(id).then(({ sample, path, data }) => {
+      const { audioBuffer } = sample
+
       return Promise.all([
         readId3Tags(data),
         calculateBeatGrid(audioBuffer)


### PR DESCRIPTION
this one is probably easiest to read commit by commit.

in this PR i convert all uses of `isLoading`, `isSaving`, etc to be an array eg `saving: [ids]`. i then combine this information in the getters to be used in templates.

the net effect here is two things - we now prevent dirty transitions on mix overview, woot!
![image](https://cloud.githubusercontent.com/assets/1360563/21957386/b7a97c98-da49-11e6-854b-e4dd27eab3c1.png)

and we keep seamlessly keep track of loading, creating, analyzing samples. this is after i dropped 27 large mp3 files onto the page
![image](https://cloud.githubusercontent.com/assets/1360563/21957403/13661e38-da4a-11e6-8ed6-6cfdfdc06a69.png)

