### PR TITLE
feature/delete-track-row

### DIFF
--- a/audio/actions.js
+++ b/audio/actions.js
@@ -1,0 +1,6 @@
+const { createActions } = require('redux-actions')
+
+module.exports = createActions(
+  'UPDATE_AUDIO_GRAPH',
+  'UPDATE_VIRTUAL_AUDIO_GRAPH'
+)

--- a/audio/helpers/create-audio-graph.js
+++ b/audio/helpers/create-audio-graph.js
@@ -1,0 +1,35 @@
+const { map, merge, forEach } = require('lodash')
+
+module.exports = createAudioGraph
+
+function createAudioGraph ({ channel, audioContext, outputs = 'output' }) {
+  const { channels: nestedChannels = [] } = channel
+  const { currentTime } = audioContext
+
+  const nestedAudioGraphs = map(nestedChannels, (nestedChannel, i) =>
+    createAudioGraph({
+      channel: nestedChannel,
+      audioContext,
+      outputs: { key: channel.id } // outputs: [0], inputs: [i]
+    })
+  )
+
+  // create clip nodes
+  // create FX chain
+  // create channel merge input (how many inputs?)
+
+  const audioGraph = {
+    [channel.id]: ['channelMerger', outputs, { numberOfInputs: nestedChannels.length }],
+  }
+
+  forEach(channel.clips, clip => {
+    audioGraph[clip.id] = ['oscillator', channel.id, {
+      type: 'square',
+      frequency: 440,
+      startTime: currentTime + 1,
+      stopTime: currentTime + 2
+    }]
+  })
+
+  return merge(audioGraph, ...nestedAudioGraphs)
+}

--- a/audio/helpers/create-audio-graph.js
+++ b/audio/helpers/create-audio-graph.js
@@ -10,16 +10,18 @@ function createAudioGraph ({ channel, audioContext, outputs = 'output' }) {
     createAudioGraph({
       channel: nestedChannel,
       audioContext,
-      outputs: { key: channel.id } // outputs: [0], inputs: [i]
+      outputs: { key: channel.id, outputs: [i], inputs: [0] }
     })
   )
 
-  // create clip nodes
+  // TODO:
+  // create clip nodes (soundtouch source node)
   // create FX chain
-  // create channel merge input (how many inputs?)
+  // add automations
 
   const audioGraph = {
-    [channel.id]: ['channelMerger', outputs, { numberOfInputs: nestedChannels.length }],
+    // NOTE: virtual-audio-graph interprets numberOfOutputs here as the # of merger inputs
+    [channel.id]: ['channelMerger', outputs, { numberOfOutputs: nestedChannels.length }],
   }
 
   forEach(channel.clips, clip => {

--- a/audio/helpers/create-audio-graph.js
+++ b/audio/helpers/create-audio-graph.js
@@ -14,22 +14,21 @@ function createAudioGraph ({ channel, audioContext, outputs = 'output' }) {
     })
   )
 
-  // TODO:
+  // TODO(FUTURE):
   // create clip nodes (soundtouch source node)
   // create FX chain
   // add automations
 
   const audioGraph = {
     // NOTE: virtual-audio-graph interprets numberOfOutputs here as the # of merger inputs
-    [channel.id]: ['channelMerger', outputs, { numberOfOutputs: nestedChannels.length }],
+    [channel.id]: ['channelMerger', outputs, { numberOfOutputs: nestedChannels.length }]
   }
 
   forEach(channel.clips, clip => {
-    audioGraph[clip.id] = ['oscillator', channel.id, {
-      type: 'square',
-      frequency: 440,
+    audioGraph[clip.id] = ['bufferSource', channel.id, {
+      buffer: clip.sample.audioBuffer,
       startTime: currentTime + 1,
-      stopTime: currentTime + 2
+      stopTime: currentTime + 100
     }]
   })
 

--- a/audio/helpers/create-audio-graph.test.js
+++ b/audio/helpers/create-audio-graph.test.js
@@ -30,22 +30,22 @@ test('createAudioGraph', (t) => {
   }
 
   const expected = {
-    'masterChannelId': ['channelMerger', 'output', { numberOfInputs: 2 }],
+    'masterChannelId': ['channelMerger', 'output', { numberOfOutputs: 2 }],
     'channel1Id': ['channelMerger',
-      { key: 'masterChannelId' },
-      { numberOfInputs: 2 }
+      { key: 'masterChannelId', outputs: [0], inputs: [0] },
+      { numberOfOutputs: 2 }
     ],
     'channel2Id': ['channelMerger',
-      { key: 'channel1Id' },
-      { numberOfInputs: 0 }
+      { key: 'channel1Id', outputs: [0], inputs: [0] },
+      { numberOfOutputs: 0 }
     ],
     'channel3Id': ['channelMerger',
-      { key: 'channel1Id' },
-      { numberOfInputs: 0 }
+      { key: 'channel1Id', outputs: [1], inputs: [0] },
+      { numberOfOutputs: 0 }
     ],
     'channel4Id': ['channelMerger',
-      { key: 'masterChannelId' },
-      { numberOfInputs: 0 }
+      { key: 'masterChannelId', outputs: [1], inputs: [0] },
+      { numberOfOutputs: 0 }
     ],
     'clip1Id': ['oscillator', 'channel3Id', {
       type: 'square',
@@ -54,6 +54,7 @@ test('createAudioGraph', (t) => {
       stopTime: currentTime + 2
     }]
   }
+
 
   const actual = createAudioGraph({
     channel: masterChannel,

--- a/audio/helpers/create-audio-graph.test.js
+++ b/audio/helpers/create-audio-graph.test.js
@@ -19,7 +19,10 @@ test('createAudioGraph', (t) => {
         type: 'type3',
         clips: [{
           id: 'clip1Id',
-          sampleId: 'beat.wav'
+          sampleId: 'beat.wav',
+          sample: {
+            audioBuffer: 'clip1AudioBuffer'
+          }
         }]
       }]
     }, {
@@ -47,14 +50,12 @@ test('createAudioGraph', (t) => {
       { key: 'masterChannelId', outputs: [1], inputs: [0] },
       { numberOfOutputs: 0 }
     ],
-    'clip1Id': ['oscillator', 'channel3Id', {
-      type: 'square',
-      frequency: 440,
+    'clip1Id': ['bufferSource', 'channel3Id', {
+      buffer: 'clip1AudioBuffer',
       startTime: currentTime + 1,
-      stopTime: currentTime + 2
+      stopTime: currentTime + 100
     }]
   }
-
 
   const actual = createAudioGraph({
     channel: masterChannel,

--- a/audio/helpers/create-audio-graph.test.js
+++ b/audio/helpers/create-audio-graph.test.js
@@ -1,0 +1,63 @@
+const test = require('ava')
+
+const createAudioGraph = require('./create-audio-graph')
+
+test('createAudioGraph', (t) => {
+  const currentTime = 4
+
+  const masterChannel = {
+    id: 'masterChannelId',
+    type: 'type0',
+    channels: [{
+      id: 'channel1Id',
+      type: 'type1',
+      channels: [{
+        id: 'channel2Id',
+        type: 'type2'
+      }, {
+        id: 'channel3Id',
+        type: 'type3',
+        clips: [{
+          id: 'clip1Id',
+          sampleId: 'beat.wav'
+        }]
+      }]
+    }, {
+      id: 'channel4Id',
+      type: 'type4',
+      channels: []
+    }]
+  }
+
+  const expected = {
+    'masterChannelId': ['channelMerger', 'output', { numberOfInputs: 2 }],
+    'channel1Id': ['channelMerger',
+      { key: 'masterChannelId' },
+      { numberOfInputs: 2 }
+    ],
+    'channel2Id': ['channelMerger',
+      { key: 'channel1Id' },
+      { numberOfInputs: 0 }
+    ],
+    'channel3Id': ['channelMerger',
+      { key: 'channel1Id' },
+      { numberOfInputs: 0 }
+    ],
+    'channel4Id': ['channelMerger',
+      { key: 'masterChannelId' },
+      { numberOfInputs: 0 }
+    ],
+    'clip1Id': ['oscillator', 'channel3Id', {
+      type: 'square',
+      frequency: 440,
+      startTime: currentTime + 1,
+      stopTime: currentTime + 2
+    }]
+  }
+
+  const actual = createAudioGraph({
+    channel: masterChannel,
+    audioContext: { currentTime }
+  })
+  t.deepEqual(actual, expected)
+})

--- a/audio/reducer.js
+++ b/audio/reducer.js
@@ -1,7 +1,7 @@
 const { Effects, loop } = require('redux-loop')
 const { handleActions } = require('redux-actions')
-const { map, defaults, without, omit } = require('lodash')
 const createVirtualAudioGraph = require('virtual-audio-graph')
+const assert = require('assert')
 
 const {
   updateAudioGraph,
@@ -15,6 +15,8 @@ function createReducer (config) {
   return handleActions({
     [updateAudioGraph]: (state, action) => {
       const channel = action.payload
+      assert(channel.status === 'loaded', 'Requires loaded channel to updateAudioGraph')
+
       const audioGraph = createAudioGraph({ channel, audioContext: state.audioContext })
 
       return loop({
@@ -48,6 +50,6 @@ function createReducer (config) {
   }, {
     audioGraphs: {},
     virtualAudioGraphs: {},
-    audioContext: config.audioContext,
+    audioContext: config.audioContext
   })
 }

--- a/audio/reducer.js
+++ b/audio/reducer.js
@@ -1,0 +1,46 @@
+const { Effects, loop } = require('redux-loop')
+const { handleActions } = require('redux-actions')
+const { map, defaults, without, omit } = require('lodash')
+const config = require('./config')
+const createVirtualAudioGraph = require('virtual-audio-graph')
+
+const {
+  updateAudioGraph,
+  updateVirtualAudioGraph
+} = require('./actions')
+
+module.exports = createReducer
+
+function createReducer (config) {
+  return handleActions({
+    [updateAudioGraph]: (state, action) => {
+      const channel = action.payload
+      const audioGraph = createAudioGraph({ channel, state.audioContext })
+
+      const nestedChannelEffects = map(channel.channels, nestedChannel =>
+        Effects.constant(updateAudioGraph(nestedChannel)))
+
+      return loop({
+        ...state,
+        audioGraphs: {
+          ...state.audioGraphs,
+          [channel.id]: audioGraph
+        }
+      }, Effects.batch([updateVirtualAudioGraph(channel.id)].concat(nestedChannelEffects)))
+    },
+    [updateVirtualAudioGraph]: (state, action) => {
+      const channelId = action.payload
+      const audioGraph = state.audioGraphs[channelId]
+      if (!audioGraph) { return }
+
+      const virtualAudioGraph = state.virtualAudioGraphs[channelId] || 
+
+
+    }
+  }, {
+    audioGraphs: {},
+    virtualAudioGraphs: {},
+    masterChannels: {},
+    audioContext: config.audioContext,
+  })
+}

--- a/channels/helpers/nest.js
+++ b/channels/helpers/nest.js
@@ -1,4 +1,4 @@
-const { includes, some } = require('lodash')
+const { includes, some, every } = require('lodash')
 
 module.exports = nestChannels
 
@@ -11,10 +11,18 @@ function nestChannels ({ channelId, channels, clips, dirtyChannels = [] }) {
   })
   const childClips = clipIds.map(clipId => (clips[clipId] || {}))
 
+  let status = 'unloaded'
+  if (some(childChannels, { status: 'loading' }) || some(childClips, { status: 'loading' })) {
+    status = 'loading'
+  } else if (every(childChannels, { status: 'loaded' }) && every(childClips, { status: 'loaded' })) {
+    status = 'loaded'
+  }
+
   return {
     id,
     type,
     startBeat,
+    status,
     isDirty: (includes(dirtyChannels, id) ||
       some(childChannels, { isDirty: true }) ||
       some(childClips, { isDirty: true })),

--- a/channels/helpers/nest.test.js
+++ b/channels/helpers/nest.test.js
@@ -8,7 +8,7 @@ test('nest', (t) => {
       id: 0,
       startBeat: 0,
       type: 'type0',
-      channelIds: [1, 4]
+      channelIds: [1, 4, 5, 6]
     },
     1: {
       id: 1,
@@ -31,14 +31,42 @@ test('nest', (t) => {
       id: 4,
       startBeat: 4,
       type: 'type4',
-      channelIds: []
+      channelIds: [],
+      clipIds: []
+    },
+    5: {
+      id: 5,
+      startBeat: 5,
+      type: 'type5',
+      channelIds: [],
+      clipIds: ['beat2']
+    },
+    6: {
+      id: 6,
+      startBeat: 6,
+      type: 'type6',
+      channelIds: [],
+      clipIds: ['beat3']
     }
   }
   const clips = {
     beat: {
       id: 'beat',
       sampleId: 'beat.wav',
-      isDirty: true
+      isDirty: true,
+      status: 'loading'
+    },
+    beat2: {
+      id: 'beat2',
+      sampleId: 'beat2.wav',
+      isDirty: false,
+      status: 'loaded'
+    },
+    beat3: {
+      id: 'beat3',
+      sampleId: 'beat3.wav',
+      isDirty: true,
+      status: 'unloaded'
     }
   }
   const dirtyChannels = [4]
@@ -47,16 +75,19 @@ test('nest', (t) => {
     id: 0,
     startBeat: 0,
     type: 'type0',
+    status: 'loading',
     isDirty: true,
     channels: [{
       id: 1,
       startBeat: 1,
       type: 'type1',
+      status: 'loading',
       isDirty: true,
       channels: [{
         id: 2,
         startBeat: 2,
         type: 'type2',
+        status: 'loaded',
         isDirty: false,
         channels: [],
         clips: []
@@ -64,12 +95,14 @@ test('nest', (t) => {
         id: 3,
         startBeat: 3,
         type: 'type3',
+        status: 'loading',
         isDirty: true,
         channels: [],
         clips: [{
           id: 'beat',
           sampleId: 'beat.wav',
-          isDirty: true
+          isDirty: true,
+          status: 'loading'
         }]
       }],
       clips: []
@@ -77,9 +110,36 @@ test('nest', (t) => {
       id: 4,
       startBeat: 4,
       type: 'type4',
+      status: 'loaded',
       isDirty: true,
       channels: [],
       clips: []
+    }, {
+      id: 5,
+      startBeat: 5,
+      type: 'type5',
+      status: 'loaded',
+      isDirty: false,
+      channels: [],
+      clips: [{
+        id: 'beat2',
+        sampleId: 'beat2.wav',
+        isDirty: false,
+        status: 'loaded'
+      }]
+    }, {
+      id: 6,
+      startBeat: 6,
+      type: 'type6',
+      status: 'unloaded',
+      isDirty: true,
+      channels: [],
+      clips: [{
+        id: 'beat3',
+        sampleId: 'beat3.wav',
+        isDirty: true,
+        status: 'unloaded'
+      }]
     }],
     clips: []
   }

--- a/clips/getters.js
+++ b/clips/getters.js
@@ -1,16 +1,30 @@
 const { createSelector: Getter } = require('reselect')
 const { mapValues, includes } = require('lodash')
 
+const { getSamples } = require('../samples/getters')
+
 const getClipsRecords = (state) => state.clips.records
 const getClipsDirty = (state) => state.clips.dirty
 
 const getClips = Getter(
   getClipsRecords,
   getClipsDirty,
-  (clips, dirtyClips) => {
+  getSamples,
+  (clips, dirtyClips, samples) => {
     return mapValues(clips, clip => {
+      const sample = samples[clip.sampleId] || {}
+
+      let status = 'unloaded'
+      if (sample.isLoading) {
+        status = 'loading'
+      } else if (sample.audioBuffer) {
+        status = 'loaded'
+      }
+
       return {
         ...clip,
+        status,
+        sample,
         isDirty: includes(dirtyClips, clip.id)
       }
     })

--- a/metas/reducer.js
+++ b/metas/reducer.js
@@ -1,6 +1,6 @@
 const { Effects, loop } = require('redux-loop')
 const { handleActions } = require('redux-actions')
-const { merge, keyBy, without } = require('lodash')
+const { assign, keyBy, without, omit } = require('lodash')
 const assert = require('assert')
 
 const {
@@ -39,7 +39,7 @@ function createReducer (config) {
     ])),
     [loadMetaListSuccess]: (state, action) => ({
       ...state,
-      records: merge({}, state.records, keyBy(action.payload, 'id'))
+      records: assign({}, state.records, keyBy(action.payload, 'id'))
     }),
     [loadMetaListFailure]: (state, action) => ({
       ...state, error: action.payload.message
@@ -88,18 +88,11 @@ function createReducer (config) {
       Effects.promise(runDeleteMeta, action.payload),
       Effects.constant(deleteMetaEnd(action.payload))
     ])),
-    [deleteMetaSuccess]: (state, action) => {
-      const metaId = action.payload
-
-      const nextRecords = { ...state.records }
-      delete nextRecords[metaId]
-
-      return {
-        ...state,
-        dirty: without(state.dirty, metaId),
-        records: nextRecords
-      }
-    },
+    [deleteMetaSuccess]: (state, action) => ({
+      ...state,
+      dirty: without(state.dirty, action.payload),
+      records: omit(state.records, action.payload)
+    }),
     [deleteMetaFailure]: (state, action) => ({
       ...state, error: action.payload.message
     }),
@@ -130,7 +123,7 @@ function createReducer (config) {
         dirty: [...state.dirty, id],
         records: {
           ...state.records,
-          [id]: merge(state.records[id], action.payload)
+          [id]: assign({}, state.records[id], action.payload)
         }
       }
     }

--- a/mixes/actions.js
+++ b/mixes/actions.js
@@ -20,6 +20,7 @@ module.exports = createActions(
   'SET_MIX',
   'CREATE_MIX',
   'REORDER_PRIMARY_TRACK',
+  'UNSET_PRIMARY_TRACK_FROM_MIX',
   'NAVIGATE_TO_MIX',
   'NAVIGATE_TO_MIX_LIST'
 )

--- a/mixes/components/primary-track-row.js
+++ b/mixes/components/primary-track-row.js
@@ -34,7 +34,7 @@ class PrimaryTrackRow extends React.Component {
 
     return connectDropTarget(connectDragSource(
       <div
-        className={classnames('rt-tr', className, dropClassName,
+        className={classnames('rt-tr', 'primary-track-row', className, dropClassName,
           draggingClassName, draggableClassName)}
         style={style}
         onClick={onClick}

--- a/mixes/components/primary-track-table.js
+++ b/mixes/components/primary-track-table.js
@@ -42,16 +42,21 @@ class PrimaryTrackTable extends React.Component {
       isLoading,
       isOver,
       canDrop,
-      connectDropTarget
+      connectDropTarget,
+      removeTrack
     } = this.props
 
     const columns = [{
       id: 'index',
       header: '#',
+      sort: 'asc',
       accessor: track => track.index + 1,
       // providing this render function allows PrimaryTrackRow to access the track object
-      render: props => <span>{props.value}</span>,
-      width: 30
+      render: props => <span>
+        {props.value}
+        <button className='delete-button' onClick={() => removeTrack(props.row.id)}>x</button>
+      </span>,
+      width: 60
     }, {
       header: 'Title',
       accessor: 'meta.title',
@@ -63,14 +68,19 @@ class PrimaryTrackTable extends React.Component {
       minWidth: 100,
       render: props => <span title={props.value}>{props.value}</span>
     }, {
-      header: 'Key',
-      accessor: 'meta.key',
+      header: 'Start',
+      accessor: 'channel.startBeat',
       minWidth: 70,
       maxWidth: 100
     }, {
       header: 'Bpm',
       accessor: 'meta.bpm',
       minWidth: 50,
+      maxWidth: 100
+    }, {
+      header: 'Key',
+      accessor: 'meta.key',
+      minWidth: 70,
       maxWidth: 100
     }]
 

--- a/mixes/containers/mix.js
+++ b/mixes/containers/mix.js
@@ -6,6 +6,7 @@ const { getMixProps } = require('../getters')
 const { saveMix, loadMix, deleteMix,
   reorderPrimaryTrack, unsetPrimaryTrackFromMix } = require('../actions')
 const { updateMeta } = require('../../metas/actions')
+const { updateAudioGraph } = require('../../audio/actions')
 const { createPrimaryTrackFromFile } = require('../../channels/actions')
 const { isValidNumber } = require('../../lib/number-utils')
 const PrimaryTrackTable = require('../components/primary-track-table')
@@ -36,7 +37,7 @@ class MixContainer extends React.Component {
 
   render () {
     const { mix, error, sampleError, saveMix, deleteMix, reorderPrimaryTrack,
-      unsetPrimaryTrackFromMix } = this.props
+      unsetPrimaryTrackFromMix, updateAudioGraph } = this.props
     if (!mix) { return null }
     console.log('mix', mix)
 
@@ -57,6 +58,9 @@ class MixContainer extends React.Component {
         </button>
         <button disabled={isLoading || isSaving} onClick={() => deleteMix(mix.id)}>
           Delete Mix
+        </button>
+        <button onClick={() => updateAudioGraph(mix && mix.channel)}>
+          Play Mix
         </button>
       </header>
       <section>
@@ -106,6 +110,7 @@ module.exports = connect(
     updateMeta,
     createPrimaryTrackFromFile,
     reorderPrimaryTrack,
-    unsetPrimaryTrackFromMix
+    unsetPrimaryTrackFromMix,
+    updateAudioGraph
   }
 )(MixContainer)

--- a/mixes/containers/mix.js
+++ b/mixes/containers/mix.js
@@ -42,12 +42,19 @@ class MixContainer extends React.Component {
     console.log('mix', mix)
 
     const { isSaving, isLoading, isDirty } = mix
-    const titleElement = isLoading
-      ? <div>'{mix.meta.title}' is loading</div>
-      : <input type='text'
+    const { status: masterChannelStatus } = mix.channel
+
+    let titleElement
+    if (isLoading) {
+      titleElement = <div>'{mix.meta.title}' is loading…</div>
+    } else if (masterChannelStatus === 'loading') {
+      titleElement = <div>loading audio…</div>
+    } else {
+      titleElement = <input type='text'
         value={mix.meta.title}
         placeholder='Untitled Mix'
         onChange={this.onChangeMixTitle.bind(this)} />
+    }
 
     return <div>
       <header>
@@ -59,7 +66,9 @@ class MixContainer extends React.Component {
         <button disabled={isLoading || isSaving} onClick={() => deleteMix(mix.id)}>
           Delete Mix
         </button>
-        <button onClick={() => updateAudioGraph(mix && mix.channel)}>
+        <button
+          disabled={masterChannelStatus !== 'loaded'}
+          onClick={() => updateAudioGraph(mix && mix.channel)}>
           Play Mix
         </button>
       </header>

--- a/mixes/containers/mix.js
+++ b/mixes/containers/mix.js
@@ -3,7 +3,8 @@ const { connect } = require('react-redux')
 const { forEach, last, get } = require('lodash')
 
 const { getMixProps } = require('../getters')
-const { saveMix, loadMix, deleteMix, reorderPrimaryTrack } = require('../actions')
+const { saveMix, loadMix, deleteMix,
+  reorderPrimaryTrack, unsetPrimaryTrackFromMix } = require('../actions')
 const { updateMeta } = require('../../metas/actions')
 const { createPrimaryTrackFromFile } = require('../../channels/actions')
 const { isValidNumber } = require('../../lib/number-utils')
@@ -34,7 +35,8 @@ class MixContainer extends React.Component {
   }
 
   render () {
-    const { mix, error, sampleError, saveMix, deleteMix, reorderPrimaryTrack } = this.props
+    const { mix, error, sampleError, saveMix, deleteMix, reorderPrimaryTrack,
+      unsetPrimaryTrackFromMix } = this.props
     if (!mix) { return null }
     console.log('mix', mix)
 
@@ -53,7 +55,7 @@ class MixContainer extends React.Component {
         <button disabled={!isDirty || (isLoading || isSaving)} onClick={() => saveMix(mix)}>
           Save Mix
         </button>
-        <button disabled={isLoading || isSaving} onClick={() => deleteMix(mix)}>
+        <button disabled={isLoading || isSaving} onClick={() => deleteMix(mix.id)}>
           Delete Mix
         </button>
       </header>
@@ -63,6 +65,8 @@ class MixContainer extends React.Component {
           reorderPrimaryTrack={reorderPrimaryTrack}
           isLoading={isLoading}
           onFilesDrop={this.onFilesDrop.bind(this)}
+          removeTrack={primaryTrackId => unsetPrimaryTrackFromMix({
+            id: mix.id, primaryTrackId })}
         />
       </section>
     </div>
@@ -95,5 +99,13 @@ module.exports = connect(
 
     return { ...props, mix }
   },
-  { saveMix, loadMix, deleteMix, updateMeta, createPrimaryTrackFromFile, reorderPrimaryTrack }
+  {
+    saveMix,
+    loadMix,
+    deleteMix,
+    updateMeta,
+    createPrimaryTrackFromFile,
+    reorderPrimaryTrack,
+    unsetPrimaryTrackFromMix
+  }
 )(MixContainer)

--- a/mixes/getters.js
+++ b/mixes/getters.js
@@ -4,7 +4,6 @@ const { mapValues, values, includes } = require('lodash')
 const { getMetas } = require('../metas/getters')
 const { getChannels } = require('../channels/getters')
 const { getSamplesError } = require('../samples/getters')
-const { getClips } = require('../clips/getters')
 const { getPrimaryTracks } = require('./helpers/get-tracks')
 
 const getMixesRecords = (state) => state.mixes.records
@@ -18,11 +17,10 @@ const getMixes = Getter(
   getMixesRecords,
   getMetas,
   getChannels,
-  getClips,
   getMixesSaving,
   getMixesLoading,
   getMixesDirty,
-  (mixes, metas, channels, clips, saving, loading, dirtyMixes) => {
+  (mixes, metas, channels, saving, loading, dirtyMixes) => {
     return mapValues(mixes, ({ id, channelId }) => {
       const meta = metas[id] || {}
       const channel = channels[channelId] || {}

--- a/mixes/service.js
+++ b/mixes/service.js
@@ -37,8 +37,8 @@ function createService (config) {
     return fs.writeFile(path, JSON.stringify(mix, null, 2), 'utf8')
   }
 
-  function deleteMix (mix) {
-    const path = _getMixPath(mix.id)
+  function deleteMix (id) {
+    const path = _getMixPath(id)
     return fs.unlink(path)
   }
 

--- a/package.json
+++ b/package.json
@@ -49,7 +49,8 @@
     "redux-logger": "^2.7.4",
     "redux-loop": "^2.2.2",
     "reselect": "^2.5.4",
-    "uuid": "^3.0.1"
+    "uuid": "^3.0.1",
+    "virtual-audio-graph": "^0.18.4"
   },
   "devDependencies": {
     "ava": "^0.17.0",

--- a/reducer.js
+++ b/reducer.js
@@ -10,6 +10,7 @@ function createReducer (config) {
     samples: require('./samples/reducer')(config),
     channels: require('./channels/reducer')(config),
     clips: require('./clips/reducer')(config),
-    metas: require('./metas/reducer')(config)
+    metas: require('./metas/reducer')(config),
+    audio: require('./audio/reducer')(config)
   })
 }

--- a/samples/getters.js
+++ b/samples/getters.js
@@ -42,6 +42,7 @@ const getSampleProps = Struct({
 })
 
 module.exports = {
+  getSamples,
   getSampleListProps,
   getSampleProps,
   getSamplesError

--- a/samples/reducer.js
+++ b/samples/reducer.js
@@ -1,6 +1,6 @@
 const { Effects, loop } = require('redux-loop')
 const { handleActions } = require('redux-actions')
-const { merge, keyBy, without, includes } = require('lodash')
+const { assign, keyBy, without, includes } = require('lodash')
 const assert = require('assert')
 
 const {
@@ -45,7 +45,7 @@ function createReducer (config) {
     ])),
     [loadSampleListSuccess]: (state, action) => ({
       ...state,
-      records: merge({}, state.records, keyBy(action.payload, 'id'))
+      records: assign({}, state.records, keyBy(action.payload, 'id'))
     }),
     [loadSampleListFailure]: (state, action) => ({
       ...state, error: action.payload.message

--- a/samples/reducer.js
+++ b/samples/reducer.js
@@ -60,7 +60,12 @@ function createReducer (config) {
         return state
       } else {
         return loop({
-          ...state, loading: [...state.loading, id]
+          ...state,
+          loading: [...state.loading, id],
+          records: {
+            ...state.records,
+            [id]: state.records[id] || { id }
+          }
         }, Effects.batch([
           Effects.promise(runLoadSample, id),
           Effects.constant(loadSampleEnd(id))

--- a/styles/file-drop.css
+++ b/styles/file-drop.css
@@ -17,11 +17,24 @@
   }
 }
 
+
+
 .primary-track-table-drag-over {
   background-color: rgba(0,0,0,0);
-  
+
   animation: glow .5s;
   animation-fill-mode: forwards;
+}
+
+
+
+.primary-track-row .delete-button {
+  visibility: hidden;
+  cursor: pointer;
+}
+
+.primary-track-row:hover .delete-button {
+  visibility: visible;
 }
 
 .primary-track-row-drag-over {


### PR DESCRIPTION
- add button to remove primary track from mix
- add unsetPrimaryTrackFromMix action.
- update deleteMix, unsetChannels, undirtyChannels, unsetClips, undirtyClips to all take id instead of object
- update all uses of `assign`, `defaults`, and `merge` to NOT mutate existing objects. i did not realize that `merge` is recursive where `assign` is not! led to a subtle bug
- update all methods that delete from store to NOT mutate store

![delete track](https://cloud.githubusercontent.com/assets/1360563/22407889/fa364812-e623-11e6-9dff-018d3ca81f04.gif)
